### PR TITLE
feat: refresh matrix task cards

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,5 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Container, Stack, useClipboard, useDisclosure } from "@chakra-ui/react";
-import { bucket } from "./model.js";
 import {
   addProject as addProjectHelper,
   buildSnapshot,
@@ -19,6 +18,7 @@ import {
 import { TOOLBAR_SORTS, projectSectionsFrom } from "./toolbar.js";
 import { buildJSONExport, parseJSONInput } from "./jsonEditor.js";
 import { createTaskPayload } from "./taskFactory.js";
+import { deriveTaskPriority } from "./utils/taskPriority.js";
 import AddTaskModal from "./components/AddTaskModal.jsx";
 import GlobalToolbar from "./components/GlobalToolbar.jsx";
 import TaskEditor from "./components/TaskEditor.jsx";
@@ -150,13 +150,8 @@ export default function App() {
 
     tasks.forEach((task, index) => {
       if (task.done) return;
-      const rawUrgency = task.urgency;
-      const urgencyScore = rawUrgency ?? 0;
-      const importanceScore = task.importance ?? 0;
-      const dueBucket = bucket(task, now);
-      const isUrgent =
-        urgencyScore >= 3 || (rawUrgency == null && dueBucket === "Today");
-      const isImportant = importanceScore >= 3;
+      const priority = deriveTaskPriority(task, now);
+      const { isUrgent, isImportant } = priority;
 
       if (!shouldIncludeTaskInMatrix(task, matrixFilters)) return;
 

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,9 +1,9 @@
 import { useCallback, useEffect, useState } from "react";
-import { Box, Flex, Heading, HStack, Tag, Text } from "@chakra-ui/react";
+import { Box, Flex, Heading, HStack, Tag, Text, Wrap } from "@chakra-ui/react";
 import { CheckIcon } from "@chakra-ui/icons";
 import { motion } from "framer-motion";
 import EffortSlider from "../EffortSlider.jsx";
-import { score } from "../model.js";
+import { deriveTaskPriority } from "../utils/taskPriority.js";
 
 const MotionCircle = motion(Box);
 
@@ -11,6 +11,7 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
   const { task, index } = item;
   const [isPopping, setPopping] = useState(false);
   const [isDragging, setDragging] = useState(false);
+  const priority = deriveTaskPriority(task);
 
   const handleEffortUpdate = useCallback(
     (value) => {
@@ -61,19 +62,18 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
       cursor={draggable ? "grab" : "pointer"}
       borderWidth="1px"
       borderRadius="xl"
-      p={4}
+      p={3}
       bg={task.done ? "gray.100" : "white"}
       boxShadow={isDragging ? "lg" : "sm"}
       transition="all 0.15s ease"
       _hover={{ boxShadow: "lg", transform: "translateY(-2px)" }}
       display="flex"
       flexDirection="column"
-      gap={3}
+      gap={2.5}
     >
-      <Flex align="center" gap={3}>
+      <Flex align="flex-start" gap={3}>
         <MotionCircle
-          w={8}
-          h={8}
+          boxSize={7}
           borderRadius="full"
           borderWidth="2px"
           borderColor={task.done ? "green.400" : "gray.300"}
@@ -88,14 +88,48 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
           whileTap={{ scale: 0.9 }}
           animate={isPopping ? { scale: [1, 1.2, 1], rotate: [0, -5, 5, 0] } : {}}
           transition={{ duration: 0.25, ease: "easeOut" }}
+          flexShrink={0}
         >
           {task.done ? <CheckIcon w={3} h={3} /> : null}
         </MotionCircle>
-        <Box>
-          <Heading as="h3" size="sm">
-            {task.title}
-          </Heading>
-          <Text fontSize="sm" color="gray.500">
+        <Box flex="1" minW={0}>
+          <Flex
+            align="flex-start"
+            justify="space-between"
+            gap={2}
+            wrap="wrap"
+          >
+            <Heading
+              as="h3"
+              fontSize="sm"
+              lineHeight="short"
+              fontWeight="semibold"
+              flex="1"
+              minW={0}
+              noOfLines={2}
+            >
+              {task.title}
+            </Heading>
+            <HStack spacing={1} flexWrap="wrap" justify="flex-end">
+              <Tag
+                size="sm"
+                colorScheme={priority.urgencyColorScheme}
+                variant="subtle"
+                borderRadius="full"
+              >
+                {priority.urgencyLabel}
+              </Tag>
+              <Tag
+                size="sm"
+                colorScheme={priority.importanceColorScheme}
+                variant="subtle"
+                borderRadius="full"
+              >
+                {priority.importanceLabel}
+              </Tag>
+            </HStack>
+          </Flex>
+          <Text fontSize="xs" color="gray.500" mt={1} noOfLines={2}>
             {task.notes ? task.notes : "Click to edit details"}
           </Text>
         </Box>
@@ -105,14 +139,26 @@ export default function TaskCard({ item, onEdit, onToggleDone, onEffortChange, d
         onMouseDown={(event) => event.stopPropagation()}
         onTouchStart={(event) => event.stopPropagation()}
         onPointerDown={(event) => event.stopPropagation()}
+        borderRadius="lg"
+        bg={task.done ? "white" : "gray.50"}
+        p={2}
       >
         <EffortSlider value={task.effort} onChange={handleEffortUpdate} size="sm" isCompact />
       </Box>
-      <HStack spacing={2} flexWrap="wrap">
-        {task.project ? <Tag colorScheme="purple">{task.project}</Tag> : null}
-        {task.due ? <Tag colorScheme="orange">Due {task.due}</Tag> : null}
-        <Tag colorScheme="blue">Score {score(task)}</Tag>
-      </HStack>
+      {task.project || task.due ? (
+        <Wrap spacing={2} shouldWrapChildren>
+          {task.project ? (
+            <Tag size="sm" colorScheme="purple" variant="subtle">
+              {task.project}
+            </Tag>
+          ) : null}
+          {task.due ? (
+            <Tag size="sm" colorScheme="orange" variant="subtle">
+              Due {task.due}
+            </Tag>
+          ) : null}
+        </Wrap>
+      ) : null}
     </Box>
   );
 }

--- a/src/utils/taskPriority.js
+++ b/src/utils/taskPriority.js
@@ -1,0 +1,30 @@
+import { bucket } from "../model.js";
+
+function isUrgent(task, now) {
+  const rawUrgency = task?.urgency;
+  const urgencyScore = rawUrgency ?? 0;
+  if (urgencyScore >= 3) return true;
+  if (rawUrgency == null) {
+    return bucket(task, now) === "Today";
+  }
+  return false;
+}
+
+function isImportant(task) {
+  const importanceScore = task?.importance ?? 0;
+  return importanceScore >= 3;
+}
+
+export function deriveTaskPriority(task, now = new Date()) {
+  const urgent = isUrgent(task, now);
+  const important = isImportant(task);
+
+  return {
+    isUrgent: urgent,
+    isImportant: important,
+    urgencyLabel: urgent ? "Urgent" : "Can wait",
+    urgencyColorScheme: urgent ? "red" : "cyan",
+    importanceLabel: important ? "Important" : "Low priority",
+    importanceColorScheme: important ? "purple" : "gray"
+  };
+}


### PR DESCRIPTION
## Summary
- centralize priority evaluation in a new helper so urgency/importance logic stays consistent across the app
- redesign matrix task cards with denser typography, status chips, and refreshed slider styling for better readability at scale
- remove score badges and ensure metadata wraps gracefully to keep cards tidy with many tasks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cafea7d05c833198d67c8abd8c4b23