### PR TITLE
Add system-aware dark mode toggle

### DIFF
--- a/src/components/ColorModeToggle.jsx
+++ b/src/components/ColorModeToggle.jsx
@@ -1,0 +1,38 @@
+import { FormControl, FormLabel, Switch, useColorMode } from "@chakra-ui/react";
+import { useEffect } from "react";
+
+export default function ColorModeToggle() {
+  const { colorMode, setColorMode, toggleColorMode } = useColorMode();
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+    const syncWithSystem = (event) => {
+      setColorMode(event.matches ? "dark" : "light");
+    };
+    if (mediaQuery.addEventListener) {
+      mediaQuery.addEventListener("change", syncWithSystem);
+    } else {
+      mediaQuery.addListener(syncWithSystem);
+    }
+    return () => {
+      if (mediaQuery.removeEventListener) {
+        mediaQuery.removeEventListener("change", syncWithSystem);
+      } else {
+        mediaQuery.removeListener(syncWithSystem);
+      }
+    };
+  }, [setColorMode]);
+  return (
+    <FormControl display="flex" alignItems="center" width="auto">
+      <FormLabel htmlFor="workspace-color-mode" mb="0" fontSize="sm" fontWeight="medium">
+        Dark mode
+      </FormLabel>
+      <Switch
+        id="workspace-color-mode"
+        colorScheme="purple"
+        isChecked={colorMode === "dark"}
+        onChange={toggleColorMode}
+      />
+    </FormControl>
+  );
+}

--- a/src/components/WorkspaceHeader.jsx
+++ b/src/components/WorkspaceHeader.jsx
@@ -18,6 +18,7 @@ import { ChevronDownIcon } from "@chakra-ui/icons";
 import SaveStatusIndicator from "./SaveStatusIndicator.jsx";
 import { HEADER_LAYOUT } from "../layout.js";
 import { WORKSPACE_HEADER_ACTION_SPACING, WORKSPACE_HEADER_MENU_STYLES } from "./componentTokens.js";
+import ColorModeToggle from "./ColorModeToggle.jsx";
 
 export default function WorkspaceHeader({
   onAddTask,
@@ -45,6 +46,9 @@ export default function WorkspaceHeader({
         <Wrap spacing={3} align="center">
           <WrapItem>
             <SaveStatusIndicator state={saveState} onSave={onSave} />
+          </WrapItem>
+          <WrapItem>
+            <ColorModeToggle />
           </WrapItem>
           <WrapItem>
             <FormControl display="flex" alignItems="center" width="auto">

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,8 +6,8 @@ import "./style.css";
 
 const theme = extendTheme({
   config: {
-    initialColorMode: "light",
-    useSystemColorMode: false
+    initialColorMode: "system",
+    useSystemColorMode: true
   }
 });
 


### PR DESCRIPTION
## Summary
- enable Chakra's system color mode support and expose a workspace toggle for dark mode
- synchronize the UI color mode with operating system preference changes

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cb2318e5b48331aba04ccacc891d03