### PR TITLE
fix: toggle focus switch and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,12 @@
 
 [Jump straight to the live board](https://ashokfernandez.github.io/FocusBadger/)
 
-FocusBadger is the cheeky little strategist that keeps your todo list honest. Drop in every task fighting for attention and it whispers back a plan: what’s urgent, what’s truly important, how heavy each lift will be, and which move fits your current mood. It’s your friendly accomplice for building momentum, not another dashboard nagging you about overdue chores.
+FocusBadger is the cheeky little strategist that keeps your todo list honest. Drop in every task fighting for attention and it whispers back a plan: what’s urgent, what’s truly important, how heavy each lift will be, and which move fits your current focus. It’s your friendly accomplice for building momentum, not another dashboard nagging you about overdue chores.
 
 ## Why FocusBadger?
 
 - **See the whole story.** Each card shows urgency, importance, and effort so you can quickly decide which bets matter now and which can wait.
-- **Match the moment.** Drag cards between "Today," "This Week," and "Later" to shape a realistic plan, then flip the mood switch to spotlight the next 1–5 tasks that match your energy.
+- **Match the moment.** Drag cards between "Today," "This Week," and "Later" to shape a realistic plan, then flip the focus switch to spotlight the next 1–5 tasks that match your energy.
 - **Stay grounded.** Gather work, home, and side quests into one calm view so nothing slips.
 - **Own your data.** Everything lives in approachable JSONL that plays nicely with Git, scripts, and AI helpers.
 
@@ -28,7 +28,7 @@ Curious how the task file is structured? Peek at the [data guide](DATA.md).
 
 1. Brain-dump projects and tasks into the board, tagging owners or themes as you go.
 2. Drag cards between lanes to sketch the rhythm of the week.
-3. Hit the mood switch whenever your energy shifts—FocusBadger reshuffles to highlight the next best bite, and you can tweak how many cards glow from the settings menu.
+3. Hit the focus switch whenever your energy shifts—FocusBadger reshuffles to highlight the next best bite, and you can tweak how many cards glow from the settings menu.
 4. Share the board with an AI assistant for fast edits or summaries using the workflow in [AI_ASSIST.md](AI_ASSIST.md).
 5. Celebrate wins and capture learnings before rolling unfinished work forward.
 

--- a/src/components/MatrixSortControl.jsx
+++ b/src/components/MatrixSortControl.jsx
@@ -5,7 +5,7 @@ import { MATRIX_SORTS } from "../matrix.js";
 
 export default function MatrixSortControl({ value, onChange }) {
   const options = useMemo(() => MATRIX_SORT_OPTION_CONFIG, []);
-  const moodStyles = useMemo(
+  const focusStyles = useMemo(
     () => ({
       [MATRIX_SORTS.SCORE]: {
         colorScheme: "red",
@@ -22,7 +22,7 @@ export default function MatrixSortControl({ value, onChange }) {
   return (
     <HStack spacing={2} align="center">
       <Text fontSize="xs" fontWeight="semibold" textTransform="uppercase" letterSpacing="wide" color="purple.500">
-        Mood
+        Focus
       </Text>
       {options.map((option) => {
         const isActive = value === option.value;
@@ -31,10 +31,13 @@ export default function MatrixSortControl({ value, onChange }) {
             key={option.value}
             size="xs"
             variant={isActive ? "solid" : "outline"}
-            colorScheme={isActive ? moodStyles[option.value]?.colorScheme ?? "purple" : "gray"}
-            boxShadow={isActive ? moodStyles[option.value]?.shadow : undefined}
+            colorScheme={isActive ? focusStyles[option.value]?.colorScheme ?? "purple" : "gray"}
+            boxShadow={isActive ? focusStyles[option.value]?.shadow : undefined}
             onClick={() => {
-              if (isActive) return;
+              if (isActive) {
+                onChange(null);
+                return;
+              }
               onChange(option.value);
             }}
             aria-pressed={isActive}

--- a/src/components/WorkspaceHeader.jsx
+++ b/src/components/WorkspaceHeader.jsx
@@ -147,17 +147,17 @@ export default function WorkspaceHeader({
                     <Flex align="center" justify="space-between" w="full" gap={4}>
                       <Box>
                         <Text fontSize="sm" fontWeight="medium">
-                          Mood highlights
+                          Focus highlights
                         </Text>
                         <Text fontSize="xs" color={colors.textSubtle}>
-                          Choose how many tasks glow when the mood switch is on.
+                          Choose how many tasks glow when the focus switch is on.
                         </Text>
                       </Box>
                       <Flex align="center" gap={2}>
                         <IconButton
                           size="xs"
                           variant="outline"
-                          aria-label="Decrease mood highlight count"
+                          aria-label="Decrease focus highlight count"
                           icon={<MinusIcon />}
                           isDisabled={!canDecreaseMoodHighlights}
                           onClick={(event) => {
@@ -176,7 +176,7 @@ export default function WorkspaceHeader({
                         <IconButton
                           size="xs"
                           variant="outline"
-                          aria-label="Increase mood highlight count"
+                          aria-label="Increase focus highlight count"
                           icon={<AddIcon />}
                           isDisabled={!canIncreaseMoodHighlights}
                           onClick={(event) => {

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -86,7 +86,7 @@ describe("matrix sorting", () => {
   });
 });
 
-describe("task mood highlight", () => {
+describe("task focus highlight", () => {
   it("respects highlighted selection when provided for priority mode", () => {
     const highlightSet = new Set([2]);
     const task = { urgency: 4, importance: 5 };
@@ -145,7 +145,7 @@ describe("task mood highlight", () => {
     ).toBe(false);
   });
 
-  it("does not flag highlights when no mood is selected", () => {
+  it("does not flag highlights when no focus is selected", () => {
     const sample = { urgency: 5, importance: 5, effort: 1 };
     const { isPriorityHighlight, isLowEffortHighlight } = getTaskMoodHighlight(sample, undefined);
     expect(isPriorityHighlight).toBe(false);
@@ -166,6 +166,16 @@ describe("highlight selection", () => {
 
     const selected = selectHighlightTaskIndexes(tasks, MATRIX_SORTS.SCORE);
     expect(Array.from(selected)).toEqual([0, 4, 2]);
+  });
+
+  it("returns an empty set when focus highlights are turned off", () => {
+    const tasks = [
+      { urgency: 5, importance: 5, effort: 5 },
+      { urgency: 3, importance: 4, effort: 2 }
+    ];
+
+    const selected = selectHighlightTaskIndexes(tasks, undefined);
+    expect(selected.size).toBe(0);
   });
 
   it("picks tasks by urgency, importance, then effort when the limit increases", () => {
@@ -219,7 +229,7 @@ describe("highlight selection", () => {
   });
 });
 
-describe("project mood highlight", () => {
+describe("project focus highlight", () => {
   it("surfaces priority highlight when any task qualifies", () => {
     const items = [
       { index: 1, task: { urgency: 1, importance: 1 } },


### PR DESCRIPTION
## Summary
- allow the focus switch buttons to toggle off by reselecting an active mode and relabel the control
- update header copy and README to refer to the focus switch terminology
- refresh matrix highlight tests to use the new wording and cover the off state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cd62b42f7483319087b6ff5e7c95dd