### PR TITLE
feat: add list sort control and refine focus order

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -43,6 +43,7 @@ import PriorityMatrixSection from "./components/PriorityMatrixSection.jsx";
 import ProjectsPanel from "./components/ProjectsPanel.jsx";
 import AssistantWorkflowModal from "./components/AssistantWorkflowModal.jsx";
 import MatrixSortControl from "./components/MatrixSortControl.jsx";
+import ListSortControl from "./components/ListSortControl.jsx";
 const DEFAULT_MATRIX_FILTERS = [ALL_PROJECTS];
 const STORAGE_MODE_KEY = "taskbadger:storageMode";
 const STORAGE_MODE_LOCAL = "local";
@@ -56,7 +57,7 @@ export default function App() {
   const [matrixFilters, setMatrixFilters] = useState(DEFAULT_MATRIX_FILTERS);
   const [matrixSortMode, setMatrixSortMode] = useState(MATRIX_SORTS.SCORE);
   const [moodHighlightLimit, setMoodHighlightLimit] = useState(3);
-  const projectSortMode = TOOLBAR_SORTS.SCORE;
+  const [listSortMode, setListSortMode] = useState(TOOLBAR_SORTS.MOST_RECENT);
   const fileHandleRef = useRef(null);
   const disclosure = useDisclosure();
   const projectManagerDisclosure = useDisclosure();
@@ -235,12 +236,12 @@ export default function App() {
     });
 
     return {
-      today: sortMatrixEntries(groups.today, matrixSortMode),
-      schedule: sortMatrixEntries(groups.schedule, matrixSortMode),
-      delegate: sortMatrixEntries(groups.delegate, matrixSortMode),
-      consider: sortMatrixEntries(groups.consider, matrixSortMode)
+      today: sortMatrixEntries(groups.today, matrixSortMode, { now, listSortMode }),
+      schedule: sortMatrixEntries(groups.schedule, matrixSortMode, { now, listSortMode }),
+      delegate: sortMatrixEntries(groups.delegate, matrixSortMode, { now, listSortMode }),
+      consider: sortMatrixEntries(groups.consider, matrixSortMode, { now, listSortMode })
     };
-  }, [tasks, matrixFilters, matrixSortMode, highlightNow]);
+  }, [tasks, matrixFilters, matrixSortMode, highlightNow, listSortMode]);
 
   const highlightedTaskIndexes = useMemo(
     () =>
@@ -253,8 +254,8 @@ export default function App() {
   );
 
   const projectGroups = useMemo(
-    () => projectSectionsFrom(tasks, projects, projectSortMode, matrixFilters),
-    [tasks, projects, projectSortMode, matrixFilters]
+    () => projectSectionsFrom(tasks, projects, listSortMode, matrixFilters),
+    [tasks, projects, listSortMode, matrixFilters]
   );
 
   const projectUsage = useMemo(() => {
@@ -849,7 +850,9 @@ export default function App() {
                     filterOptions={matrixFilterOptions}
                     activeFilters={matrixFilters}
                     onToggleFilter={toggleMatrixFilter}
-                  />
+                  >
+                    <ListSortControl value={listSortMode} onChange={setListSortMode} label="Sort" />
+                  </GlobalToolbar>
                   <Box
                     maxH={{ base: "none", lg: "80vh" }}
                     overflowY={{ base: "visible", lg: "auto" }}
@@ -871,19 +874,28 @@ export default function App() {
                 </Stack>
               </TabPanel>
               <TabPanel px={0} pt={0}>
-                <ProjectsPanel
-                  projectGroups={projectGroups}
-                  onManageProjects={projectManagerDisclosure.onOpen}
-                  onAddTask={addTaskDisclosure.onOpen}
-                  onRenameProject={renameProject}
-                  onRenameTask={handleTaskTitleRename}
-                  onEditTask={handleOpenEditor}
-                  onToggleTask={handleToggleDone}
-                  onDropProject={handleProjectDrop}
-                  onEffortChange={handleEffortCommit}
-                  highlightMode={matrixSortMode}
-                  highlightedTaskIndexes={highlightedTaskIndexes}
-                />
+                <Stack spacing={4}>
+                  <GlobalToolbar
+                    filterOptions={matrixFilterOptions}
+                    activeFilters={matrixFilters}
+                    onToggleFilter={toggleMatrixFilter}
+                  >
+                    <ListSortControl value={listSortMode} onChange={setListSortMode} label="Sort" />
+                  </GlobalToolbar>
+                  <ProjectsPanel
+                    projectGroups={projectGroups}
+                    onManageProjects={projectManagerDisclosure.onOpen}
+                    onAddTask={addTaskDisclosure.onOpen}
+                    onRenameProject={renameProject}
+                    onRenameTask={handleTaskTitleRename}
+                    onEditTask={handleOpenEditor}
+                    onToggleTask={handleToggleDone}
+                    onDropProject={handleProjectDrop}
+                    onEffortChange={handleEffortCommit}
+                    highlightMode={matrixSortMode}
+                    highlightedTaskIndexes={highlightedTaskIndexes}
+                  />
+                </Stack>
               </TabPanel>
             </TabPanels>
           </Stack>

--- a/src/components/ListSortControl.jsx
+++ b/src/components/ListSortControl.jsx
@@ -1,0 +1,43 @@
+import { useMemo } from "react";
+import { Button, HStack, Menu, MenuButton, MenuItem, MenuList, Text } from "@chakra-ui/react";
+import { ChevronDownIcon } from "@chakra-ui/icons";
+import { GLOBAL_TOOLBAR_SORT_OPTIONS } from "./componentTokens.js";
+
+export default function ListSortControl({ value, onChange, label = "Sort" }) {
+  const options = useMemo(() => GLOBAL_TOOLBAR_SORT_OPTIONS, []);
+  const activeOption = useMemo(
+    () => options.find((option) => option.value === value) ?? options[0],
+    [options, value]
+  );
+
+  return (
+    <Menu>
+      <MenuButton as={Button} size="sm" variant="outline" colorScheme="purple" rightIcon={<ChevronDownIcon />}
+        aria-label={`${label}: ${activeOption.label}`}>
+        <HStack spacing={1}>
+          <Text fontSize="xs" textTransform="uppercase" fontWeight="semibold" letterSpacing="wide">
+            {label}
+          </Text>
+          <Text fontSize="sm" fontWeight="semibold">
+            {activeOption.label}
+          </Text>
+        </HStack>
+      </MenuButton>
+      <MenuList>
+        {options.map((option) => (
+          <MenuItem
+            key={option.value}
+            onClick={() => {
+              if (option.value === activeOption.value) return;
+              onChange?.(option.value);
+            }}
+            aria-checked={option.value === activeOption.value}
+            role="menuitemradio"
+          >
+            {option.label}
+          </MenuItem>
+        ))}
+      </MenuList>
+    </Menu>
+  );
+}

--- a/src/components/componentTokens.js
+++ b/src/components/componentTokens.js
@@ -10,9 +10,9 @@ export const MATRIX_SORT_OPTION_CONFIG = [
 ];
 
 export const GLOBAL_TOOLBAR_SORT_OPTIONS = [
-  { value: TOOLBAR_SORTS.SCORE, label: "Score (highest first)" },
-  { value: TOOLBAR_SORTS.DUE_DATE, label: "Due date (earliest)" },
-  { value: TOOLBAR_SORTS.TITLE, label: "Title (A–Z)" }
+  { value: TOOLBAR_SORTS.LOWEST_EFFORT, label: "Lowest Effort" },
+  { value: TOOLBAR_SORTS.OLDEST, label: "Oldest" },
+  { value: TOOLBAR_SORTS.MOST_RECENT, label: "Most Recent" }
 ];
 
 export const GLOBAL_TOOLBAR_STACK_SPACING = { base: 3, md: 4 };

--- a/src/listSorts.js
+++ b/src/listSorts.js
@@ -1,0 +1,7 @@
+export const LIST_SORTS = {
+  LOWEST_EFFORT: "lowest-effort",
+  OLDEST: "oldest",
+  MOST_RECENT: "most-recent"
+};
+
+export default LIST_SORTS;

--- a/test/layout.test.js
+++ b/test/layout.test.js
@@ -50,11 +50,7 @@ describe("responsive layout", () => {
 
   it("exposes toolbar sort options for readability", () => {
     const labels = GLOBAL_TOOLBAR_SORT_OPTIONS.map((option) => option.label);
-    expect(labels).toEqual([
-      "Score (highest first)",
-      "Due date (earliest)",
-      "Title (A–Z)"
-    ]);
+    expect(labels).toEqual(["Lowest Effort", "Oldest", "Most Recent"]);
   });
 
   it("keeps workspace actions touch friendly", () => {

--- a/test/matrix.test.js
+++ b/test/matrix.test.js
@@ -12,6 +12,7 @@ import {
   shouldIncludeTaskInMatrix,
   sortMatrixEntries
 } from "../src/matrix.js";
+import { LIST_SORTS } from "../src/listSorts.js";
 
 describe("matrix filters", () => {
   it("normalizes project names", () => {
@@ -43,7 +44,7 @@ describe("matrix filters", () => {
 describe("matrix sorting", () => {
   const wrap = (task) => ({ task });
 
-  it("sorts by score when no mode provided", () => {
+  it("sorts by urgency, importance, then effort in priority mode", () => {
     const items = [
       wrap({ title: "Charlie", importance: 1, urgency: 3, effort: 1 }),
       wrap({ title: "Alpha", importance: 2, urgency: 1, effort: 1 }),
@@ -52,8 +53,8 @@ describe("matrix sorting", () => {
 
     const sorted = sortMatrixEntries(items);
     expect(sorted.map((entry) => entry.task.title)).toEqual([
-      "Alpha",
       "Charlie",
+      "Alpha",
       "Bravo"
     ]);
   });
@@ -73,6 +74,29 @@ describe("matrix sorting", () => {
       "Heavy",
       "Unknown"
     ]);
+  });
+
+  it("respects list sort overrides", () => {
+    const items = [
+      wrap({ title: "Alpha", created: "2024-01-02", effort: 3 }),
+      wrap({ title: "Bravo", created: "2024-01-01", effort: 1 }),
+      wrap({ title: "Charlie", effort: 2 })
+    ];
+
+    const oldest = sortMatrixEntries(items, MATRIX_SORTS.SCORE, {
+      listSortMode: LIST_SORTS.OLDEST
+    });
+    expect(oldest.map((entry) => entry.task.title)).toEqual(["Bravo", "Alpha", "Charlie"]);
+
+    const mostRecent = sortMatrixEntries(items, MATRIX_SORTS.SCORE, {
+      listSortMode: LIST_SORTS.MOST_RECENT
+    });
+    expect(mostRecent.map((entry) => entry.task.title)).toEqual(["Alpha", "Bravo", "Charlie"]);
+
+    const lowestEffort = sortMatrixEntries(items, MATRIX_SORTS.SCORE, {
+      listSortMode: LIST_SORTS.LOWEST_EFFORT
+    });
+    expect(lowestEffort.map((entry) => entry.task.title)).toEqual(["Bravo", "Charlie", "Alpha"]);
   });
 
   it("falls back to score ordering for equal effort values", () => {

--- a/test/toolbar.test.js
+++ b/test/toolbar.test.js
@@ -28,7 +28,7 @@ describe("project sections", () => {
   const projectList = ["Alpha", "Beta"];
 
   it("returns all sections when filters include all projects", () => {
-    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.SCORE, [ALL_PROJECTS]);
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.MOST_RECENT, [ALL_PROJECTS]);
     expect(sections.length).toBe(3);
     expect(sections.map((section) => section.name)).toEqual(["Alpha", "Beta", UNASSIGNED_LABEL]);
     expect(sections[0].openItems.length).toBe(2);
@@ -36,13 +36,13 @@ describe("project sections", () => {
   });
 
   it("includes only matching projects when filters are scoped", () => {
-    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.SCORE, ["Beta"]);
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.MOST_RECENT, ["Beta"]);
     expect(sections.length).toBe(1);
     expect(sections[0].name).toBe("Beta");
   });
 
   it("includes unassigned section when requested", () => {
-    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.TITLE, [UNASSIGNED_LABEL]);
+    const sections = projectSectionsFrom(tasks, projectList, TOOLBAR_SORTS.MOST_RECENT, [UNASSIGNED_LABEL]);
     expect(sections.length).toBe(1);
     expect(sections[0].name).toBe(UNASSIGNED_LABEL);
     expect(sections[0].openItems.map((entry) => entry.index)).toEqual([3]);
@@ -50,19 +50,24 @@ describe("project sections", () => {
 
   it("omits unassigned section when there are no unassigned tasks", () => {
     const assignedOnly = tasks.slice(0, 3);
-    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.SCORE, [ALL_PROJECTS]);
+    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.MOST_RECENT, [ALL_PROJECTS]);
     expect(sections.map((section) => section.name)).toEqual(["Alpha", "Beta"]);
   });
 
   it("returns no sections when filtering for unassigned without matches", () => {
     const assignedOnly = tasks.slice(0, 3);
-    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.SCORE, [UNASSIGNED_LABEL]);
+    const sections = projectSectionsFrom(assignedOnly, projectList, TOOLBAR_SORTS.MOST_RECENT, [UNASSIGNED_LABEL]);
     expect(sections.length).toBe(0);
   });
 
   it("separates closed tasks into dedicated buckets", () => {
     const closedTask = { title: "Done", project: "Alpha", done: true };
-    const sections = projectSectionsFrom([...tasks, closedTask], projectList, TOOLBAR_SORTS.SCORE, [ALL_PROJECTS]);
+    const sections = projectSectionsFrom(
+      [...tasks, closedTask],
+      projectList,
+      TOOLBAR_SORTS.MOST_RECENT,
+      [ALL_PROJECTS]
+    );
     const alpha = sections.find((section) => section.name === "Alpha");
     expect(alpha.openItems.some((entry) => entry.task.title === "Done")).toBe(false);
     const closedTitles = alpha.closedItems.map((entry) => entry.task.title);
@@ -73,36 +78,88 @@ describe("project sections", () => {
 
 describe("toolbar project sorting", () => {
   const sample = [
-    { index: 0, task: { title: "Write docs", importance: 3, urgency: 2, effort: 1 } },
-    { index: 1, task: { title: "Review PR", importance: 4, urgency: 4, effort: 1 } },
-    { index: 2, task: { title: "Plan sprint", importance: 4, urgency: 1, effort: 3 } },
-    { index: 3, task: { title: "Archive", done: true, importance: 5, urgency: 5, effort: 1 } }
+    {
+      index: 0,
+      task: {
+        title: "Write docs",
+        importance: 3,
+        urgency: 2,
+        effort: 1,
+        created: "2024-01-15T10:00:00Z"
+      }
+    },
+    {
+      index: 1,
+      task: {
+        title: "Review PR",
+        importance: 4,
+        urgency: 4,
+        effort: 1,
+        created: "2024-02-01T09:00:00Z"
+      }
+    },
+    {
+      index: 2,
+      task: {
+        title: "Plan sprint",
+        importance: 4,
+        urgency: 1,
+        effort: 3,
+        created: "2023-12-01T12:00:00Z"
+      }
+    },
+    {
+      index: 3,
+      task: {
+        title: "Archive",
+        done: true,
+        importance: 5,
+        urgency: 5,
+        effort: 1,
+        created: "2022-01-01T08:00:00Z"
+      }
+    }
   ];
 
   it("keeps incomplete tasks before completed ones", () => {
-    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.SCORE);
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.MOST_RECENT);
     expect(sorted.at(-1).task.done).toBe(true);
   });
 
-  it("sorts by score descending when mode is score", () => {
-    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.SCORE);
-    expect(sorted[0].task.title).toBe("Review PR");
+  it("sorts by lowest effort when requested", () => {
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.LOWEST_EFFORT);
+    expect(sorted.map((entry) => entry.task.title)).toEqual([
+      "Review PR",
+      "Write docs",
+      "Plan sprint",
+      "Archive"
+    ]);
   });
 
-  it("sorts by due date ascending when mode is due date", () => {
-    const items = [
-      { index: 0, task: { title: "B", due: "2025-01-01" } },
-      { index: 1, task: { title: "A", due: "2024-12-01" } },
-      { index: 2, task: { title: "C" } }
-    ];
-    const sorted = sortProjectItems(items, TOOLBAR_SORTS.DUE_DATE);
-    expect(sorted.map((item) => item.task.title)).toEqual(["A", "B", "C"]);
+  it("sorts by oldest created date when requested", () => {
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.OLDEST);
+    expect(sorted.map((entry) => entry.task.title)).toEqual([
+      "Plan sprint",
+      "Write docs",
+      "Review PR",
+      "Archive"
+    ]);
   });
 
-  it("falls back to alphabetical ordering when titles differ", () => {
-    const a = { index: 0, task: { title: "alpha" } };
-    const b = { index: 1, task: { title: "Beta" } };
-    const comparison = compareProjectItems(a, b, TOOLBAR_SORTS.TITLE);
+  it("sorts by most recent created date by default", () => {
+    const sorted = sortProjectItems(sample, TOOLBAR_SORTS.MOST_RECENT);
+    expect(sorted.map((entry) => entry.task.title)).toEqual([
+      "Review PR",
+      "Write docs",
+      "Plan sprint",
+      "Archive"
+    ]);
+  });
+
+  it("falls back to score ordering when metadata matches", () => {
+    const first = { index: 0, task: { effort: 2, importance: 4, urgency: 4 } };
+    const second = { index: 1, task: { effort: 2, importance: 3, urgency: 3 } };
+    const comparison = compareProjectItems(first, second, TOOLBAR_SORTS.LOWEST_EFFORT);
     expect(comparison < 0).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary
- align the matrix focus ordering with urgency/importance tie-breaks and add support for list-level sort overrides
- add a reusable list sort control and surface it next to the project filter on both workspace tabs
- update toolbar sorting logic and accompanying tests to cover the new "Lowest Effort", "Oldest", and "Most Recent" options

## Testing
- npm test


------
https://chatgpt.com/codex/tasks/task_e_68cd6a593068833180904c7d36252089